### PR TITLE
Support for multiple methods and/or paths at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ mock.add({
 })
 ```
 
+You can also specify multiple methods and/or paths at the same time:
+```js
+// This mock will catch every search request against any index
+mock.add({
+  method: ['GET', 'POST'],
+  path: ['/_search', '/:index/_search']
+}, () => {
+  return { status: 'ok' }
+})
+```
+
 #### `get`
 
 Returns the matching resolver function for the given pattern, it returns `null` if there is not a matching pattern.

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,10 @@ declare class ClientMock {
 export declare type ResolverFn = (params: MockPattern) => Record<string, any> | string
 
 export interface MockPattern {
-  method: string
-  path: string
+  method: string | string[]
+  path: string | string[]
   querystring?: Record<string, string>
-  body?: Record<string, any>
+  body?: Record<string, any> | Record<string, any>[]
 }
 
 export default ClientMock

--- a/index.js
+++ b/index.js
@@ -28,6 +28,15 @@ class Mocker {
   }
 
   add (pattern, fn) {
+    for (const key of ['method', 'path']) {
+      if (Array.isArray(pattern[key])) {
+        for (const value of pattern[key]) {
+          this.add({ ...pattern, [key]: value }, fn)
+        }
+        return this
+      }
+    }
+
     if (typeof pattern.method !== 'string') throw new ConfigurationError('The method is not defined')
     if (typeof pattern.path !== 'string') throw new ConfigurationError('The path is not defined')
     if (typeof fn !== 'function') throw new ConfigurationError('The resolver function is not defined')

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,6 +21,14 @@ mock.add({
 })
 
 mock.add({
+  method: ['GET', 'POST'],
+  path: ['/_search', '/:index/_search']
+}, params => {
+  expectType<MockPattern>(params)
+  return { status: 'ok' }
+})
+
+mock.add({
   method: 'GET',
   path: '/',
   querystring: { pretty: 'true' }
@@ -34,6 +42,15 @@ mock.add({
   path: '/',
   querystring: { pretty: 'true' },
   body: { foo: 'bar' }
+}, params => {
+  expectType<MockPattern>(params)
+  return { status: 'ok' }
+})
+
+mock.add({
+  method: 'POST',
+  path: '/_bulk',
+  body: [{ foo: 'bar' }]
 }, params => {
   expectType<MockPattern>(params)
   return { status: 'ok' }

--- a/test.js
+++ b/test.js
@@ -557,3 +557,110 @@ test('.add should throw if method and path are not defined', async t => {
     t.is(err.message, 'The resolver function is not defined')
   }
 })
+
+test('Define multiple methods at once', async t => {
+  const mock = new Mock()
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: mock.getConnection()
+  })
+
+  mock.add({
+    method: ['GET', 'POST'],
+    path: '/:index/_search'
+  }, () => {
+    return { status: 'ok' }
+  })
+
+  let response = await client.search({
+    index: 'test',
+    q: 'foo:bar'
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+
+  response = await client.search({
+    index: 'test',
+    body: {
+      query: { match: { foo: 'bar' } }
+    }
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+})
+
+test('Define multiple paths at once', async t => {
+  const mock = new Mock()
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: mock.getConnection()
+  })
+
+  mock.add({
+    method: 'GET',
+    path: ['/test1/_search', '/test2/_search']
+  }, () => {
+    return { status: 'ok' }
+  })
+
+  let response = await client.search({
+    index: 'test1',
+    q: 'foo:bar'
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+
+  response = await client.search({
+    index: 'test2',
+    q: 'foo:bar'
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+})
+
+test('Define multiple paths and method at once', async t => {
+  const mock = new Mock()
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: mock.getConnection()
+  })
+
+  mock.add({
+    method: ['GET', 'POST'],
+    path: ['/test1/_search', '/test2/_search']
+  }, () => {
+    return { status: 'ok' }
+  })
+
+  let response = await client.search({
+    index: 'test1',
+    q: 'foo:bar'
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+
+  response = await client.search({
+    index: 'test2',
+    q: 'foo:bar'
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+
+  response = await client.search({
+    index: 'test1',
+    body: {
+      query: { match: { foo: 'bar' } }
+    }
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+
+  response = await client.search({
+    index: 'test2',
+    body: {
+      query: { match: { foo: 'bar' } }
+    }
+  })
+  t.deepEqual(response.body, { status: 'ok' })
+  t.is(response.statusCode, 200)
+})


### PR DESCRIPTION
As titled.

```js
// This mock will catch every search request against any index
mock.add({
  method: ['GET', 'POST'],
  path: ['/_search', '/:index/_search']
}, () => {
  return { status: 'ok' }
})
```

Closes: #2