### PR TITLE
Include params in response when no mock found

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function buildConnectionClass (mocker) {
           const resolver = mocker.get(params)
 
           if (resolver === null) {
-            payload = { error: 'Mock not found' }
+            payload = { error: 'Mock not found', params }
             statusCode = 404
           } else {
             payload = resolver(params)


### PR DESCRIPTION
When none of your mocks match, it's helpful to see what the actual request was that was made by the client.