### PR TITLE
Ensure router will correctly match paths with URL-encoded characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 .DS_Store
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -55,6 +55,11 @@ class Mocker {
     if (typeof pattern.path !== 'string') throw new ConfigurationError('The path is not defined')
     if (typeof fn !== 'function') throw new ConfigurationError('The resolver function is not defined')
 
+    // workaround since find-my-way no longer decodes URI escaped chars
+    // https://github.com/delvedor/find-my-way/pull/282
+    // https://github.com/delvedor/find-my-way/pull/286
+    if (pattern.path.indexOf('%') > -1) pattern.path = decodeURIComponent(pattern.path)
+
     const handler = this[kRouter].find(pattern.method, pattern.path)
     if (handler) {
       handler.store.push({ ...pattern, fn })
@@ -64,10 +69,19 @@ class Mocker {
     } else {
       this[kRouter].on(pattern.method, pattern.path, noop, [{ ...pattern, fn }])
     }
+
     return this
   }
 
   get (params) {
+    if (typeof params.method !== 'string') throw new ConfigurationError('The method is not defined')
+    if (typeof params.path !== 'string') throw new ConfigurationError('The path is not defined')
+
+    // workaround since find-my-way no longer decodes URI escaped chars
+    // https://github.com/delvedor/find-my-way/pull/282
+    // https://github.com/delvedor/find-my-way/pull/286
+    if (params.path.indexOf('%') > -1) params.path = decodeURIComponent(params.path)
+
     const handler = this[kRouter].find(params.method, params.path)
     if (!handler) return null
     for (const { body, querystring, fn } of handler.store) {

--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
   },
   "homepage": "https://github.com/elastic/elasticsearch-js-mock#readme",
   "devDependencies": {
-    "@elastic/elasticsearch": "^8.1.0",
-    "ava": "^4.1.0",
-    "node-abort-controller": "^3.0.1",
-    "nyc": "^15.1.0",
-    "standard": "^16.0.4",
-    "tsd": "^0.19.1"
+    "@elastic/elasticsearch": "^9.0.0",
+    "ava": "^6.2.0",
+    "node-abort-controller": "^3.1.1",
+    "nyc": "^17.1.0",
+    "standard": "^17.1.2",
+    "tsd": "^0.32.0"
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "find-my-way": "^9.1.0",
+    "find-my-way": "^9.3.0",
     "into-stream": "^6.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -880,3 +880,63 @@ test('Should clear all mocks', async t => {
     t.is(err.statusCode, 404)
   }
 })
+
+test('Path should match URL-encoded characters for e.g. comma in multi-index operations', async t => {
+  t.plan(1)
+
+  const mock = new Mock()
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: mock.getConnection()
+  })
+
+  const spy = (_req, _res, _params, _store, _searchParams) => {
+    t.pass('Callback function was called')
+    return {}
+  }
+
+  mock.add(
+    {
+      method: 'DELETE',
+      path: '/some-type-index-123tobedeleted%2Csome-type-index-456tobedeleted'
+    },
+    spy
+  )
+
+  await client.indices.delete({
+    index: [
+      'some-type-index-123tobedeleted',
+      'some-type-index-456tobedeleted'
+    ]
+  })
+})
+
+test('Path should match unencoded comma in path', async t => {
+  t.plan(1)
+
+  const mock = new Mock()
+  const client = new Client({
+    node: 'http://localhost:9200',
+    Connection: mock.getConnection()
+  })
+
+  const spy = (_req, _res, _params, _store, _searchParams) => {
+    t.pass('Callback function was called')
+    return {}
+  }
+
+  mock.add(
+    {
+      method: 'DELETE',
+      path: '/some-type-index-123tobedeleted,some-type-index-456tobedeleted'
+    },
+    spy
+  )
+
+  await client.indices.delete({
+    index: [
+      'some-type-index-123tobedeleted',
+      'some-type-index-456tobedeleted'
+    ]
+  })
+})

--- a/test.js
+++ b/test.js
@@ -940,3 +940,32 @@ test('Path should match unencoded comma in path', async t => {
     ]
   })
 })
+
+test('Validate types on get()', t => {
+  t.plan(4)
+
+  const mock = new Mock()
+  mock.add(
+    {
+      method: 'GET',
+      path: '/foo'
+    },
+    () => {}
+  )
+
+  try {
+    mock.get({ method: 'GET', path: null })
+    t.fail('should throw')
+  } catch (err) {
+    t.true(err instanceof errors.ConfigurationError)
+    t.is(err.message, 'The path is not defined')
+  }
+
+  try {
+    mock.get({ method: null, path: '/foo' })
+    t.fail('should throw')
+  } catch (err) {
+    t.true(err instanceof errors.ConfigurationError)
+    t.is(err.message, 'The method is not defined')
+  }
+})


### PR DESCRIPTION
Fixes <https://github.com/elastic/elasticsearch-js-mock/issues/42>

Also adds some useful param validation on `get()` and upgrades dev dependencies + find-my-way to latest stable.
